### PR TITLE
Documentation updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,19 +107,19 @@ Index Name| Index Class |[empty]|[empty]
 - setClear(boolean clear) - Sets if the backing graph tables should be reset if they exist.
 - autoFlush(boolean autoFlush) - Sets if each graph element and property change will be flushed to the server.
 - skipExistenceChecks(boolean skip) - Sets if you want to skip existance checks when creating graph elemenets
+
 ###Accumulo Control
+
 - setUser(String user) - Sets the user to use when connecting to Accumulo
 - setPassword(byte[] password | String password) - Sets the password to use when connecting to Accumulo
 - setZookeeperHosts(String zookeeperHosts) - Sets the Zookeepers to connect to.
 - setInstanceName(String instance) - Sets the Instance name to use when connecting to Zookeeper
 - setInstanceType(InstanceType type) - Sets the type of Instance to use : Distrubuted, Mini, or Mock. Defaults to Distrubuted
-
 - setQueryThreads(int threads) - Specifies the number of threads to use in scanners. Defaults to 3
 - setMaxWriteLatency(long latency) - Sets the latency to be used for all writes to Accumulo
 - setMaxWriteTimeout(long timeout) - Sets the timeout to be used for all writes to Accumulo
 - setMaxWriteMemory(long mem) - Sets the memory buffer to be used for all writes to Accumulo
 - setMaxWriteThreads(int threads) - Sets the number of threads to be used for all writes to Accumulo
-
 - setAuthorizations(Authorizations auths) - Sets the authorizations to use when accessing the graph
 - setColumnVisibility(ColumnVisibility colVis) - TODO
 - setSplits(String splits | String[] splits) - Sets the splits to use when creating tables. Can be a space sperated list or an array of splits 
@@ -129,6 +129,7 @@ Index Name| Index Class |[empty]|[empty]
 - setLruMaxCapacity(int max) - TODO
 - setVertexCacheTimeout(int millis) - Sets the vertex cache timeout.  A value <=0 clears the value
 - setEdgeCacheTimeout(int millis)  - Sets the edge cache timeout.  A value <=0 clears the value
+
 ###Preloading
 - setPropertyCacheTimeout(int millis) - Sets the element property cache timeout. A value <=0 clears the value
 - setPreloadedProperties(String[] propertyKeys) - Sets the property keys that should be preloaded. Requiers a positive timout.


### PR DESCRIPTION
Basically moved JavaDocs into the Readme -- Should we instead have this section just point to compiled javadocs?

Seems like an ok choice for now
